### PR TITLE
replacing readable-stream with streamx

### DIFF
--- a/.github/workflows/test-node.yml
+++ b/.github/workflows/test-node.yml
@@ -1,0 +1,24 @@
+name: Test on Node.js
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+jobs:
+  build:
+    strategy:
+      matrix:
+        node-version: [10.x, 12.x, 14.x]
+        os: [ubuntu-16.04, macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+    - uses: actions/checkout@v2
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v1
+      with:
+        node-version: ${{ matrix.node-version }}
+    - run: npm install
+    - run: npm test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,0 @@
-language: node_js
-node_js:
-  - '5'
-  - '4'
-  - '0.12'
-  - '0.10'

--- a/README.md
+++ b/README.md
@@ -11,10 +11,10 @@ npm install merkle-tree-stream
 ## Usage
 
 ``` js
-var merkleStream = require('merkle-tree-stream')
+var MerkleTreeStream = require('merkle-tree-stream')
 var crypto = require('crypto')
 
-var stream = merkleStream({
+var stream = new MerkleTreeStream({
   leaf: function (leaf, roots) {
     // this function should hash incoming data
     // roots in the current partial roots of the merkle tree
@@ -74,8 +74,8 @@ to a previously generated merkle tree.
 A non stream low-level interface can required by doing `require('merkle-tree-stream/generator')`.
 
 ``` js
-var generator = require('merkle-tree-stream/generator')
-var gen = generator({leaf: ..., parent: ...}) // same options as above
+var MerkleGenerator = require('merkle-tree-stream/generator')
+var gen = new MerkleGenerator({leaf: ..., parent: ...}) // same options as above
 
 var nodes = gen.next('some data')
 console.log(nodes) // returns the tree nodes generated, similar to the stream output

--- a/example.js
+++ b/example.js
@@ -1,7 +1,7 @@
-var merkleStream = require('./')
+var MerkleTreeStream = require('./')
 var crypto = require('crypto')
 
-var stream = merkleStream({
+var stream = new MerkleTreeStream({
   leaf: function (leaf, roots) {
     return crypto.createHash('sha256').update(leaf.data).digest()
   },

--- a/generator.js
+++ b/generator.js
@@ -2,60 +2,59 @@
 // useful for certain applications the require non-streamy access to the algos.
 // versioned by the same semver as the stream interface.
 
-var flat = require('flat-tree')
+const flat = require('flat-tree')
 
-module.exports = MerkleGenerator
+module.exports = class MerkleGenerator {
+  constructor (opts, roots) {
+    if (!opts || !opts.leaf || !opts.parent) throw new Error('opts.leaf and opts.parent required')
 
-function MerkleGenerator (opts, roots) {
-  if (!(this instanceof MerkleGenerator)) return new MerkleGenerator(opts, roots)
-  if (!opts || !opts.leaf || !opts.parent) throw new Error('opts.leaf and opts.parent required')
+    this.roots = roots || opts.roots || []
+    this.blocks = this.roots.length ? 1 + flat.rightSpan(this.roots[this.roots.length - 1].index) / 2 : 0
 
-  this.roots = roots || opts.roots || []
-  this.blocks = this.roots.length ? 1 + flat.rightSpan(this.roots[this.roots.length - 1].index) / 2 : 0
-
-  for (var i = 0; i < this.roots.length; i++) {
-    var r = this.roots[i]
-    if (r && !r.parent) r.parent = flat.parent(r.index)
-  }
-
-  this._leaf = opts.leaf
-  this._parent = opts.parent
-}
-
-MerkleGenerator.prototype.next = function (data, nodes) {
-  if (!Buffer.isBuffer(data)) data = new Buffer(data)
-  if (!nodes) nodes = []
-
-  var index = 2 * this.blocks++
-
-  var leaf = {
-    index: index,
-    parent: flat.parent(index),
-    hash: null,
-    size: data.length,
-    data: data
-  }
-
-  leaf.hash = this._leaf(leaf, this.roots)
-  this.roots.push(leaf)
-  nodes.push(leaf)
-
-  while (this.roots.length > 1) {
-    var left = this.roots[this.roots.length - 2]
-    var right = this.roots[this.roots.length - 1]
-
-    if (left.parent !== right.parent) break
-
-    this.roots.pop()
-    this.roots[this.roots.length - 1] = leaf = {
-      index: left.parent,
-      parent: flat.parent(left.parent),
-      hash: this._parent(left, right),
-      size: left.size + right.size,
-      data: null
+    for (var i = 0; i < this.roots.length; i++) {
+      var r = this.roots[i]
+      if (r && !r.parent) r.parent = flat.parent(r.index)
     }
-    nodes.push(leaf)
+
+    this._leaf = opts.leaf
+    this._parent = opts.parent
   }
 
-  return nodes
+  next (data, nodes) {
+    if (!Buffer.isBuffer(data)) data = Buffer.from(data)
+    if (!nodes) nodes = []
+
+    var index = 2 * this.blocks++
+
+    var leaf = {
+      index: index,
+      parent: flat.parent(index),
+      hash: null,
+      size: data.length,
+      data: data
+    }
+
+    leaf.hash = this._leaf(leaf, this.roots)
+    this.roots.push(leaf)
+    nodes.push(leaf)
+
+    while (this.roots.length > 1) {
+      var left = this.roots[this.roots.length - 2]
+      var right = this.roots[this.roots.length - 1]
+
+      if (left.parent !== right.parent) break
+
+      this.roots.pop()
+      this.roots[this.roots.length - 1] = leaf = {
+        index: left.parent,
+        parent: flat.parent(left.parent),
+        hash: this._parent(left, right),
+        size: left.size + right.size,
+        data: null
+      }
+      nodes.push(leaf)
+    }
+
+    return nodes
+  }
 }

--- a/index.js
+++ b/index.js
@@ -1,32 +1,19 @@
-var stream = require('readable-stream')
-var util = require('util')
-var generator = require('./generator')
+const { Transform } = require('streamx')
+const MerkleGenerator = require('./generator')
 
-module.exports = MerkleTree
+module.exports = class MerkleTreeStream extends Transform {
+  constructor (opts, roots) {
+    super({highWaterMark: (opts && opts.highWaterMark) || 16})
+    if (!opts) opts = {}
+    this._generator = new MerkleGenerator(opts, roots)
+    this.roots = this._generator.roots
+    this.blocks = 0
+  }
 
-function MerkleTree (opts, roots) {
-  if (!(this instanceof MerkleTree)) return new MerkleTree(opts, roots)
-  if (!opts) opts = {}
-  this._generator = generator(opts, roots)
-  this.destroyed = false
-  this.roots = this._generator.roots
-  this.blocks = 0
-  var hwm = opts.highWaterMark || 16
-  stream.Transform.call(this, {objectMode: true, highWaterMark: hwm})
-}
-
-util.inherits(MerkleTree, stream.Transform)
-
-MerkleTree.prototype.destroy = function (err) {
-  if (this.destroyed) return
-  this.destroyed = true
-  if (err) this.emit('error', err)
-  this.emit('close')
-}
-
-MerkleTree.prototype._transform = function (data, enc, cb) {
-  var nodes = this._generator.next(data)
-  for (var i = 0; i < nodes.length; i++) this.push(nodes[i])
-  this.blocks = this._generator.blocks
-  cb()
+  _transform (data, cb) {
+    var nodes = this._generator.next(data)
+    for (var i = 0; i < nodes.length; i++) this.push(nodes[i])
+    this.blocks = this._generator.blocks
+    cb()
+  }
 }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "dependencies": {
     "flat-tree": "^1.3.0",
-    "readable-stream": "^2.0.5"
+    "streamx": "^2.7.1"
   },
   "devDependencies": {
     "standard": "^6.0.7",

--- a/test.js
+++ b/test.js
@@ -1,9 +1,9 @@
-var tape = require('tape')
-var crypto = require('crypto')
-var merkleStream = require('./')
+const tape = require('tape')
+const crypto = require('crypto')
+const MerkleTreeStream = require('./')
 
 tape('hashes', function (t) {
-  var stream = merkleStream({
+  var stream = new MerkleTreeStream({
     leaf: function (leaf) {
       return hash([leaf.data])
     },
@@ -21,13 +21,13 @@ tape('hashes', function (t) {
     parent: 1,
     hash: hash(['a']),
     size: 1,
-    data: new Buffer('a')
+    data: Buffer.from('a')
   }, {
     index: 2,
     parent: 1,
     hash: hash(['b']),
     size: 1,
-    data: new Buffer('b')
+    data: Buffer.from('b')
   }, {
     index: 1,
     parent: 3,
@@ -47,7 +47,7 @@ tape('hashes', function (t) {
 })
 
 tape('one root on power of two', function (t) {
-  var stream = merkleStream({
+  var stream = new MerkleTreeStream({
     leaf: function (leaf) {
       return hash([leaf.data])
     },
@@ -70,7 +70,7 @@ tape('one root on power of two', function (t) {
 })
 
 tape('multiple roots if not power of two', function (t) {
-  var stream = merkleStream({
+  var stream = new MerkleTreeStream({
     leaf: function (leaf) {
       return hash([leaf.data])
     },


### PR DESCRIPTION
Using `streamx` as a lovely replacement to `readable-stream`.

As the functionality of `streamx` doesn't _exactly_ cover all of `readable-stream` it already needs to be a breaking change, I also moved from a function API to a class API that requires the need for `new`. This seems to be also the streamlined way to use `streamx`.