### PR TITLE
Finalize / Close-up - prevent dangling nodes

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,19 +1,34 @@
 const { Transform } = require('streamx')
 const MerkleGenerator = require('./generator')
 
-module.exports = class MerkleTreeStream extends Transform {
+class MerkleTreeStream extends Transform {
   constructor (opts, roots) {
     super({ highWaterMark: (opts && opts.highWaterMark) || 16 })
     if (!opts) opts = {}
     this._generator = new MerkleGenerator(opts, roots)
+    this._closeUp = !!opts.closeUp
     this.roots = this._generator.roots
     this.blocks = 0
   }
 
   _transform (data, cb) {
-    const nodes = this._generator.next(data)
-    for (let i = 0; i < nodes.length; i++) this.push(nodes[i])
-    this.blocks = this._generator.blocks
+    this._pushNodes(this._generator.next(data))
     cb()
   }
+
+  _final (cb) {
+    if (this._closeUp) {
+      this._pushNodes(this._generator.next(MerkleGenerator.CLOSE_UP))
+    }
+    this.push(null)
+    cb()
+  }
+
+  _pushNodes (nodes) {
+    for (let i = 0; i < nodes.length; i++) this.push(nodes[i])
+    this.blocks = this._generator.blocks
+  }
 }
+MerkleTreeStream.CLOSE_UP = MerkleGenerator.CLOSE_UP
+
+module.exports = MerkleTreeStream

--- a/test.js
+++ b/test.js
@@ -91,6 +91,64 @@ tape('multiple roots if not power of two', function (t) {
   })
 })
 
+;[true, false].forEach(function (manual) {
+  tape('close up to one root [' + (manual ? 'manual' : 'automatic') + ']', function (t) {
+    const stream = new MerkleTreeStream({
+      leaf: function (leaf) {
+        return Buffer.from(leaf.data + leaf.data)
+      },
+      parent: function (a, b) {
+        return Buffer.concat([a.hash, b.hash])
+      },
+      closeUp: !manual
+    })
+
+    const nodes = []
+    stream.on('data', function (node) {
+      nodes.push(node)
+    })
+
+    stream.write('a')
+    stream.write('b')
+    stream.write('c')
+    stream.write('d')
+    stream.write('e')
+    if (manual) {
+      stream.write(MerkleTreeStream.CLOSE_UP)
+    }
+    stream.end()
+
+    stream.on('end', function () {
+      t.notOk(stream.roots.length > 1, 'only one root')
+      t.equal(stream.roots[0].hash.toString(), 'aabbccddeeeeeeee')
+
+      nodes.sort(function (a, b) {
+        return a.index - b.index
+      })
+
+      t.deepEqual(nodes.map(function (n) {
+        n.data = n.data && n.data.toString()
+        n.hash = n.hash.toString()
+        return n
+      }), [
+        { data: 'a', hash: 'aa', index: 0, parent: 1, size: 1 },
+        { data: null, hash: 'aabb', index: 1, parent: 3, size: 2 },
+        { data: 'b', hash: 'bb', index: 2, parent: 1, size: 1 },
+        { data: null, hash: 'aabbccdd', index: 3, parent: 7, size: 4 },
+        { data: 'c', hash: 'cc', index: 4, parent: 5, size: 1 },
+        { data: null, hash: 'ccdd', index: 5, parent: 3, size: 2 },
+        { data: 'd', hash: 'dd', index: 6, parent: 5, size: 1 },
+        { data: null, hash: 'aabbccddeeeeeeee', index: 7, parent: 15, size: 8 },
+        { data: 'e', hash: 'ee', index: 8, parent: 9, size: 1 },
+        { data: null, hash: 'eeee', index: 9, parent: 11, size: 2 },
+        { data: null, hash: 'eeeeeeee', index: 11, parent: 7, size: 4 }
+      ])
+
+      t.end()
+    })
+  })
+})
+
 function hash (list) {
   const sha = crypto.createHash('sha256')
   for (let i = 0; i < list.length; i++) sha.update(list[i])


### PR DESCRIPTION
This is a further development of the concept in #4. It is rebased _(utilizes the streamx final feature)_ and presents a slightly different API that may be more practicable.

The implementation presented in this PR forgoes to extend the stream API (`finalize`) in favor of the `CLOSE_UP` token object that can be passed to the stream for the same effect. This allows integration in more complex streaming workflows.  For convenience it also proposes a `.closeUp: true` method to the stream that "closes up" the stream at the end.

Furthermore, it comes [with documentation](https://github.com/martinheidegger/merkle-tree-stream/blob/124b6944e01a3cc39b742dd3c44c161b6d556f2d/README.md#closing-up-the-tree-and-enforcing-a-single-root) 🥳 

_Note:_ It is based on #8 as standard linting may be a bit annoying. [→ List of changes excluding the #8](https://github.com/martinheidegger/merkle-tree-stream/compare/update-deps...martinheidegger:close-up).

cc. @mvayngrib