### PR TITLE
isParent and isLeaf util

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+coverage

--- a/index.js
+++ b/index.js
@@ -4,7 +4,6 @@ const MerkleGenerator = require('./generator')
 module.exports = class MerkleTreeStream extends Transform {
   constructor (opts, roots) {
     super({ highWaterMark: (opts && opts.highWaterMark) || 16 })
-    if (!opts) opts = {}
     this._generator = new MerkleGenerator(opts, roots)
     this.roots = this._generator.roots
     this.blocks = 0

--- a/package.json
+++ b/package.json
@@ -8,11 +8,15 @@
     "streamx": "^2.11.1"
   },
   "devDependencies": {
+    "c8": "^7.11.0",
     "standard": "^16.0.3",
     "tape": "^5.3.1"
   },
   "scripts": {
-    "test": "standard && tape test.js"
+    "test": "npm run lint && npm run coverage",
+    "lint": "standard",
+    "coverage": "c8 npm run unit",
+    "unit": "tape test.js"
   },
   "repository": {
     "type": "git",

--- a/test.js
+++ b/test.js
@@ -2,6 +2,9 @@ const tape = require('tape')
 const crypto = require('crypto')
 const MerkleTreeStream = require('./')
 const MerkleGenerator = require('./generator')
+const util = require('./util')
+const isLeaf = util.isLeaf
+const isParent = util.isParent
 
 const opts = {
   leaf: function (leaf) {
@@ -127,6 +130,20 @@ tape('highwatermark while streaming', function (t) {
     highWaterMark: 8
   }))
   t.notEqual(stream, null)
+  t.end()
+})
+
+tape('isLeaf/isParent test', function (t) {
+  const gen = new MerkleGenerator(opts)
+  const nodes = []
+  gen.next('a', nodes)
+  gen.next('b', nodes)
+  ;[isLeaf, isLeaf, isParent].forEach(function (expected, index) {
+    const entry = nodes[index]
+    const unexpected = (expected === isLeaf ? isParent : isLeaf)
+    t.ok(expected(entry), 'Entry #' + index + ' ' + expected.name)
+    t.equal(unexpected(entry), false, 'Entry #' + index + ' not ' + unexpected.name)
+  })
   t.end()
 })
 

--- a/test.js
+++ b/test.js
@@ -1,16 +1,19 @@
 const tape = require('tape')
 const crypto = require('crypto')
 const MerkleTreeStream = require('./')
+const MerkleGenerator = require('./generator')
+
+const opts = {
+  leaf: function (leaf) {
+    return hash([leaf.data])
+  },
+  parent: function (a, b) {
+    return hash([a.hash, b.hash])
+  }
+}
 
 tape('hashes', function (t) {
-  const stream = new MerkleTreeStream({
-    leaf: function (leaf) {
-      return hash([leaf.data])
-    },
-    parent: function (a, b) {
-      return hash([a.hash, b.hash])
-    }
-  })
+  const stream = new MerkleTreeStream(opts)
 
   stream.write('a')
   stream.write('b')
@@ -47,14 +50,7 @@ tape('hashes', function (t) {
 })
 
 tape('one root on power of two', function (t) {
-  const stream = new MerkleTreeStream({
-    leaf: function (leaf) {
-      return hash([leaf.data])
-    },
-    parent: function (a, b) {
-      return hash([a.hash, b.hash])
-    }
-  })
+  const stream = new MerkleTreeStream(opts)
 
   stream.write('a')
   stream.write('b')
@@ -70,14 +66,7 @@ tape('one root on power of two', function (t) {
 })
 
 tape('multiple roots if not power of two', function (t) {
-  const stream = new MerkleTreeStream({
-    leaf: function (leaf) {
-      return hash([leaf.data])
-    },
-    parent: function (a, b) {
-      return hash([a.hash, b.hash])
-    }
-  })
+  const stream = new MerkleTreeStream(opts)
 
   stream.write('a')
   stream.write('b')
@@ -89,6 +78,56 @@ tape('multiple roots if not power of two', function (t) {
     t.ok(stream.roots.length > 1, 'more than one root')
     t.end()
   })
+})
+
+tape('starting of with roots for generation', function (t) {
+  // Started with nodes 'a', 'b', 'c', 'd', 'e'
+  const gen = new MerkleGenerator(Object.assign({}, opts, {
+    roots: [
+      {
+        index: 3,
+        size: 4,
+        hash: Buffer.from('14ede5e8e97ad9372327728f5099b95604a39593cac3bd38a343ad76205213e7', 'hex'),
+        data: null
+      },
+      {
+        index: 8,
+        size: 1,
+        hash: Buffer.from('3f79bb7b435b05321651daefd374cdc681dc06faa65e374e38337b88ca046dea', 'hex'),
+        data: Buffer.from('65', 'hex')
+      }
+    ]
+  }))
+  const nodes = []
+  gen.next('f', nodes)
+  gen.next('g', nodes)
+  gen.next('h', nodes)
+
+  t.deepEqual(gen.roots, [
+    {
+      index: 7,
+      parent: 15,
+      hash: Buffer.from('bd7c8a900be9b67ba7df5c78a652a8474aedd78adb5083e80e49d9479138a23f', 'hex'),
+      size: 8,
+      data: null
+    }
+  ])
+  t.end()
+})
+
+tape('requiring input leaf/parent option', function (t) {
+  t.throws(function () { return new MerkleGenerator({}) })
+  t.throws(function () { return new MerkleGenerator({ leaf: function () {} }) })
+  t.end()
+})
+
+tape('highwatermark while streaming', function (t) {
+  // verified by coverage
+  const stream = new MerkleTreeStream(Object.assign({}, opts, {
+    highWaterMark: 8
+  }))
+  t.notEqual(stream, null)
+  t.end()
 })
 
 function hash (list) {

--- a/util.js
+++ b/util.js
@@ -1,0 +1,8 @@
+module.exports = {
+  isParent: function (node) {
+    return node.data === null
+  },
+  isLeaf: function (node) {
+    return node.data !== null
+  }
+}


### PR DESCRIPTION
Based on #10, this PR adds two simple utility functions to identify parent/leaf nodes, entirely optional.